### PR TITLE
`prepare_regions.sh` now outputs `metadata.txt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.5.5.dev
+- Added code in `prepare_regions.sh` which outputs `metadata.txt` file which contains metadata about when and what version of `prepare_regions.sh` script was executed to generate the geneset data. 
+
 # v1.5.4
 Note that starting from this version, the version of the repository tag has diverged from container version. v1.5.4 is the uploaded container version, but the `burden_testing` code from v1.5.3 is used.
 

--- a/prepare_regions.sh
+++ b/prepare_regions.sh
@@ -22,8 +22,7 @@
 # For reproducibility, both the GENCODE, Ensembl and GTEx versions are hardcoded
 
 
-script_version=4.1
-last_modified=2021.Jan.19
+script_version=4.1.1
 
 ## Built in versions:
 GENCODE_release=32
@@ -232,6 +231,34 @@ echo "Re-use previous downloads: $reuse"
 echo "Download only            : $justdl"
 echo "Debug mode               : $debug_mode"
 echo ""
+
+## Write a metadata.txt file which contains info about the executed run
+metafile=${outdir}/metadata.txt
+_script_loc="`dirname \"$0\"`"
+# We use --git-dir instead of -C, because -C isn't available in older versions of git
+commit_id=$(git --git-dir ${_script_loc}/.git rev-parse HEAD)
+if [ -z "$commit_id" ] ; then
+  info "Commit ID couldn't be retrieved. Falling back to an unknown value."
+  commit_id='???'
+fi
+echo "repo-commit-id: $commit_id" > $metafile
+echo "prepare-regions-ver: $script_version" >> $metafile
+echo "GENCODE_release: $GENCODE_release" >> $metafile
+echo "Ensembl_release: $Ensembl_release" >> $metafile
+echo "GTEx_release: $GTExRelease" >> $metafile
+echo "Arguments: 
+  - outdir: $outdir
+  - tempdir: $tempdir
+  - getScores: $getScores
+  - getCadd: $getCadd
+  - backup: $backup
+  - noSums: $noSums
+  - ensftp: $ensftp
+  - reuse: $reuse
+  - justdl: $justdl
+  - debug_mode: $debug_mode
+" >> $metafile
+echo "Started: $(date +'%Y-%m-%d %H:%M:%S')" >> $metafile
 
 #===================================== VEP ===================================================
 
@@ -936,3 +963,5 @@ fi
 
 
 info "The End\n"
+
+echo "Ended: $(date +'%Y-%m-%d %H:%M:%S')" >> $metafile

--- a/prepare_regions.sh
+++ b/prepare_regions.sh
@@ -124,13 +124,13 @@ function testFileLines {
 
 # check if GZ file is OK
 function checkGZfile {
-#    echo -n "Checking GZ file integrity: $1 ... "
+    # echo -n "Checking GZ file integrity: $1 ... "
     if ! gzip -q -t "$1";then
     echo "[Error] Integrity check failed for $1"
         echo "[Error] Exit"
         exit 1
-#    else
-#    echo "OK"
+    # else
+    # echo "OK"
     fi
 }
 


### PR DESCRIPTION
`prepare_regions.sh` now generates `metadata.txt` file at the root of the output directory to indicate what version of `prepare_regions.sh` script was used, and when it was executed.

![image](https://user-images.githubusercontent.com/36769896/142377568-162ec6fc-e9b1-4a7d-844c-90094306808a.png)

#18 